### PR TITLE
Fix broken error handler and associated test

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -185,7 +185,7 @@ Persistence.keys = function(key, callback) {
 Persistence.handler = function(err) {
   if (err) {
     logging.error({ error: err.toString() });
-    if (err.toString().test(/READONLY/)) {
+    if (/READONLY/.test(err.toString())) {
       throw new Error(err);
     }
   }

--- a/test/connect.js
+++ b/test/connect.js
@@ -8,11 +8,7 @@ Persistence.setConfig(configuration);
 function Dummy () { }
 
 Dummy.prototype.toString = function() {
-  return this;
-}
-
-Dummy.prototype.test = function(pattern) {
-  return pattern == '/READONLY/'
+  return 'error string contains READONLY';
 }
 
 process.on('message', function(message) {


### PR DESCRIPTION
Prior code to verify that Persistence should crash on generating an error worked, but for the wrong reason, and it would have caused problems for other types of errors (other than writing against a READONLY instance of redis.)  This fixes the the broken code.

/cc @zendesk/zendesk-radar
### Steps to merge
- [ ] :+1: of the team
### References
- Jira link: https://zendesk.atlassian.net/browse/RADAR-408 (this was the original issue)
### Risks
- Low: Connection to redis/sentinel does not failover. 
