### PR TITLE
Add get/set methods for single keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ script:
 notifications:
   flowdock:
     secure: GzhfVfSDKQtvfCaHHh2AYTLn/kWOUvHK+SM44AfWX10pwQXCicSR5kx7jMIDrU//0+T2CP/m1EJDnK15CTix+vRJLTwybgc4b8NOl0XmnZXVcW+4i8uhKnXA3bm6+dgVxvUCwNy69dbk7H7CkyFZOzJcZCVliiRBZcbj41uwMqc=
+branches:
+  only: [master, staging, production]

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,6 @@
+### v1.0.2
+* add get/set methods for single keys
+
 ### v1.0.1
 * Crash when connection times out
 * Refactor connection.js

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An abstraction library for redis and sentinel connection management
 
 ## Copyright and license
 
-Copyright 2014 Zendesk
+Copyright 2015 Zendesk
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -135,6 +135,11 @@ Persistence.del = function(key, callback) {
   Persistence.redis().del(key, callback);
 };
 
+// Return the value associated with key that is stored in the hash *hash*
+Persistence.readHashValue = function (hash, key) {
+  return Persistence.redis.hget(hash, key);
+};
+
 Persistence.readHashAll = function(hash, callback) {
   Persistence.redis().hgetall(hash, function (err, replies) {
     if(err) throw new Error(err);
@@ -150,6 +155,18 @@ Persistence.readHashAll = function(hash, callback) {
     }
     callback(replies);
   });
+};
+
+// Return the value associated with the key *key* (no associated hash)
+Persistence.readKey = function (key) {
+  logging.debug('readKey:', key);
+  return Persistence.redis().get(key, Persistence.handler);
+};
+
+// Associate key with a single value (no associated hash)
+Persistence.persistKey = function (key, value) {
+  logging.debug('persistKey:', key, value);
+  Persistence.redis().set(key, JSON.stringify(value), Persistence.handler);
 };
 
 Persistence.persistHash = function(hash, key, value) {

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -137,7 +137,8 @@ Persistence.del = function(key, callback) {
 
 // Return the value associated with key that is stored in the hash *hash*
 Persistence.readHashValue = function (hash, key) {
-  return Persistence.redis.hget(hash, key);
+  logging.debug('readHashValue:', hash, key);
+  return Persistence.redis().hget(hash, key);
 };
 
 Persistence.readHashAll = function(hash, callback) {
@@ -158,9 +159,12 @@ Persistence.readHashAll = function(hash, callback) {
 };
 
 // Return the value associated with the key *key* (no associated hash)
-Persistence.readKey = function (key) {
+Persistence.readKey = function (key, callback) {
   logging.debug('readKey:', key);
-  return Persistence.redis().get(key, Persistence.handler);
+  Persistence.redis().get(key, function (err, reply) {
+    if(err) throw new Error(err);
+    callback(JSON.parse(reply));
+  });
 };
 
 // Associate key with a single value (no associated hash)

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -136,9 +136,12 @@ Persistence.del = function(key, callback) {
 };
 
 // Return the value associated with key that is stored in the hash *hash*
-Persistence.readHashValue = function (hash, key) {
+Persistence.readHashValue = function (hash, key, callback) {
   logging.debug('readHashValue:', hash, key);
-  return Persistence.redis().hget(hash, key);
+  Persistence.redis().hget(hash, key, function(err, reply) {
+    if (err) throw new Error(err);
+    callback(JSON.parse(reply));
+  });
 };
 
 Persistence.readHashAll = function(hash, callback) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "pretest": "npm run check-modules",
     "test-redis": "ls ./test/*.test.js | xargs -n 1 -t -I {} sh -c 'TEST=\"{}\" npm run test-one'",
     "test": "npm run test-redis",
-    "test-one": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --timeout 4000ms --bail \"$TEST\""
+    "test-one": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --timeout 4000ms --bail \"$TEST\"",
+    "test-one-solo": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --timeout 4000ms --bail"
   },
   "repository": {
     "type": "git",

--- a/test/persistence.test.js
+++ b/test/persistence.test.js
@@ -94,6 +94,21 @@ describe('given a connected persistence', function() {
         });
       });
     });
+
+    it('should get/set a single key', function(done) {
+      var key = 'persistence.messages.object.test';
+      var objectValue = {
+        foo: 'bar'
+      };
+
+      Persistence.persistKey(key, objectValue);
+      Persistence.readKey(key, function (reply) {
+        if (reply) {
+          assert.deepEqual({ foo: 'bar' }, reply);
+          done();
+        }
+      });
+    });
   });
 
 });

--- a/test/persistence.test.js
+++ b/test/persistence.test.js
@@ -95,7 +95,23 @@ describe('given a connected persistence', function() {
       });
     });
 
-    it('should get/set a single key', function(done) {
+    it('should get/set a single key from a hash', function(done) {
+      var hash = 'persistence.test';
+      var key = 'persistence.messages.object.test';
+      var objectValue = {
+        foo: 'bar'
+      };
+
+      Persistence.persistHash(hash, key, objectValue);
+      Persistence.readHashValue(hash, key, function(reply) {
+        if (reply) {
+          assert.deepEqual({ foo: 'bar' }, reply);
+          done();
+        }
+      });
+    });
+
+    it('should get/set a single standalone key', function(done) {
       var key = 'persistence.messages.object.test';
       var objectValue = {
         foo: 'bar'
@@ -109,6 +125,6 @@ describe('given a connected persistence', function() {
         }
       });
     });
-  });
 
+  });
 });


### PR DESCRIPTION
Added get/set methods for a standalone key (not associated with a specific hash).  Also, add a get method for a single key associated with a hash (set method on hash is there already). Modify travis config to limit number of PR builds.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: 

### Risks
 - Low: New methods won't affect existing use of Persistence