### PR TITLE
Update readKey, persistKey to use optional expireTTL

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -168,11 +168,12 @@ Persistence.readKey = function (key, callback, expireTTL) {
   logging.debug('readKey:', key);
   multi.get(key, function (err, reply) {
     if (err) throw new Error(err);
-    if (expireTTL) {
-      multi.expire(key, expireTTL);
-    }
     callback(JSON.parse(reply));
   });
+
+  if (expireTTL) {
+    multi.expire(key, expireTTL);
+  }
 
   multi.exec();
 };

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -166,10 +166,10 @@ Persistence.readKey = function (key, callback, expireTTL) {
   var multi = Persistence.redis().multi();
 
   logging.debug('readKey:', key);
-  Persistence.redis().get(key, function (err, reply) {
+  multi.get(key, function (err, reply) {
     if (err) throw new Error(err);
     if (expireTTL) {
-      Persistence.expire(key, expireTTL);
+      multi.expire(key, expireTTL);
     }
     callback(JSON.parse(reply));
   });
@@ -181,9 +181,9 @@ Persistence.persistKey = function (key, value, expireTTL) {
   var multi = Persistence.redis().multi();
 
   logging.debug('persistKey:', key, value);
-  Persistence.redis().set(key, JSON.stringify(value), Persistence.handler);
+  multi.set(key, JSON.stringify(value), Persistence.handler);
   if (expireTTL) {
-    Persistence.expire(key, expireTTL);
+    multi.expire(key, expireTTL);
   }
 
   multi.exec();

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -162,18 +162,31 @@ Persistence.readHashAll = function(hash, callback) {
 };
 
 // Return the value associated with the key *key* (no associated hash)
-Persistence.readKey = function (key, callback) {
+Persistence.readKey = function (key, callback, expireTTL) {
+  var multi = Persistence.redis().multi();
+
   logging.debug('readKey:', key);
   Persistence.redis().get(key, function (err, reply) {
-    if(err) throw new Error(err);
+    if (err) throw new Error(err);
+    if (expireTTL) {
+      Persistence.expire(key, expireTTL);
+    }
     callback(JSON.parse(reply));
   });
+
+  multi.exec();
 };
 
-// Associate key with a single value (no associated hash)
-Persistence.persistKey = function (key, value) {
+Persistence.persistKey = function (key, value, expireTTL) {
+  var multi = Persistence.redis().multi();
+
   logging.debug('persistKey:', key, value);
   Persistence.redis().set(key, JSON.stringify(value), Persistence.handler);
+  if (expireTTL) {
+    Persistence.expire(key, expireTTL);
+  }
+
+  multi.exec();
 };
 
 Persistence.persistHash = function(hash, key, value) {

--- a/test/persistence.test.js
+++ b/test/persistence.test.js
@@ -95,7 +95,7 @@ describe('given a connected persistence', function() {
       });
     });
 
-    it('should get/set a single key from a hash', function(done) {
+    it('should set/get a single key from a hash', function(done) {
       var hash = 'persistence.test';
       var key = 'persistence.messages.object.test';
       var objectValue = {
@@ -111,7 +111,7 @@ describe('given a connected persistence', function() {
       });
     });
 
-    it('should get/set a single standalone key', function(done) {
+    it('should set/get a single standalone key', function(done) {
       var key = 'persistence.messages.object.test';
       var objectValue = {
         foo: 'bar'
@@ -124,6 +124,40 @@ describe('given a connected persistence', function() {
           done();
         }
       });
+    });
+
+    it('should set/get a single standalone key with TTL', function(done) {
+      var key = 'persistence.messages.object.test';
+      var objectValue = {
+        foo: 'bar'
+      };
+
+      var keyTTL = 2;
+      Persistence.persistKey(key, objectValue, keyTTL);
+      Persistence.readKey(key, function (reply) {
+        if (reply) {
+          assert.deepEqual({ foo: 'bar' }, reply);
+          done();
+        }
+      });
+    });
+
+    it('should set and not get a single standalone key with expired TTL', function(done) {
+      this.timeout(4000);
+      var key = 'persistence.messages.object.test';
+      var objectValue = {
+        foo: 'bar'
+      };
+
+      var keyTTL = 2;
+      Persistence.persistKey(key, objectValue, keyTTL);
+      setTimeout(function () {
+        Persistence.readKey(key, function (reply) {
+          if (!reply) {
+            done();
+          }
+        });
+      }, 2500);
     });
 
   });

--- a/test/persistence.test.js
+++ b/test/persistence.test.js
@@ -134,6 +134,10 @@ describe('given a connected persistence', function() {
 
       var keyTTL = 2;
       Persistence.persistKey(key, objectValue, keyTTL);
+      Persistence.redis().ttl(key, function (err, remainingTTL) {
+        if (err) return done(err);
+        assert.ok(remainingTTL && (0 <= remainingTTL && remainingTTL <= 2));
+      });
       Persistence.readKey(key, function (reply) {
         if (reply) {
           assert.deepEqual({ foo: 'bar' }, reply);
@@ -151,6 +155,10 @@ describe('given a connected persistence', function() {
 
       var keyTTL = 2;
       Persistence.persistKey(key, objectValue, keyTTL);
+      Persistence.redis().ttl(key, function (err, remainingTTL) {
+        if (err) return done(err);
+        assert.ok(remainingTTL && (0 <= remainingTTL && remainingTTL <= 2));
+      });
       setTimeout(function () {
         Persistence.readKey(key, function (reply) {
           if (!reply) {


### PR DESCRIPTION
Expand readKey, persistKey to use optional expireTTL parameter.  In addition, modify readKey, persistKey to use the redis multi command, to bundle multiple commands into one call to redis.

/cc @zendesk/zendesk-radar


### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-495

### Risks
 - Low: readKey and persistKey are new API, so existing code won't break.