### PR TITLE
Pin redis to 0.12.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ script:
 notifications:
   flowdock:
     secure: GzhfVfSDKQtvfCaHHh2AYTLn/kWOUvHK+SM44AfWX10pwQXCicSR5kx7jMIDrU//0+T2CP/m1EJDnK15CTix+vRJLTwybgc4b8NOl0XmnZXVcW+4i8uhKnXA3bm6+dgVxvUCwNy69dbk7H7CkyFZOzJcZCVliiRBZcbj41uwMqc=
+sudo: false
 branches:
   only: [master, staging, production]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An abstraction library for redis and sentinel connection management
 
+## Status
+[![Build Status](https://travis-ci.org/zendesk/persistence.png?branch=master)](https://travis-ci.org/zendesk/persistence) <a href="https://codeclimate.com/github/zendesk/persistence"><img src="https://codeclimate.com/github/zendesk/persistence/badges/gpa.svg" /></a>
+
+
 ## Copyright and license
 
 Copyright 2015 Zendesk

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "callback_tracker": "*",
-    "redis": "*",
+    "redis": "0.12.1",
     "redis-sentinel": "*",
     "minilog": "*"
   }


### PR DESCRIPTION
redis@0.12.1 is the version we currently use with the zendesk_radar that is in production, so I'm pinning the radar version to this for the present, to avoid a break introduced by redis@2.0.0.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-572

### Risks
 - None