### PR TITLE
Reconnect to redis sentinel if failover happened instead of killing off host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.log
 node_modules
 *.swp
+.vscode

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -238,7 +238,15 @@ Persistence.handler = function(err) {
     logging.error(err);
 
     if (/READONLY/.test(String(err))) {
-      throw new Error(err);
+      logging.info('Failover happened, about to reconnect.');
+
+      Persistence.reconnect(function () {
+        if (connection.isReady()) {
+          logging.info('Connected successfully after failover happened.');
+        } else {
+          throw new Error('Failed to reconnect to redis after failover happened.')
+        }
+      });
     }
   }
 };
@@ -250,5 +258,17 @@ Persistence.incrby = function(key, incr) {
 Persistence.select = function(index) {
   Persistence.redis().select(index, Persistence.handler);
 };
+
+Persistence.reconnect = function (callback) {
+  Persistence.disconnect(function() {
+    ConnectionHelper.destroyConnection(configuration, function () {
+      Persistence.connect(callback);
+    })
+  })
+}
+
+Persistence.isConnectionReady = function () {
+  return connection.isReady();
+}
 
 module.exports = Persistence;

--- a/test/connect.js
+++ b/test/connect.js
@@ -11,17 +11,30 @@ Dummy.prototype.toString = function() {
   return 'error string contains READONLY';
 }
 
+var intervalCommand;
+
 process.on('message', function(message) {
-  if(message === 'connect') {
-    Persistence.connect(function() {
-      process.send('connected');
-      setInterval(function() {
-        Persistence.persistHash('xyz', 'f', 1);
-      }, 1000);
-    });
-  }
-  else if (message === 'test_error')
-  {
-    Persistence.handler(new Dummy());
+  switch (message) {
+    case 'connect':
+      Persistence.connect(function() {
+        process.send('connected');
+        intervalCommand = setInterval(function() {
+          Persistence.persistHash('xyz', 'f', 1);
+        }, 1000);
+      });
+      break;
+    case 'test_error':
+      Persistence.handler(new Dummy());
+      break;
+    case 'killoff':
+      clearInterval(intervalCommand);
+      break;
+    case 'status':
+      process.send(Persistence.isConnectionReady() ? 'valid_connection' : 'invalid_connection');
+      break;
+    default:
+      console.log('Invalid message');
   }
 });
+
+


### PR DESCRIPTION
### Description
Instead of killing of the service and reconnect again after a failover happened, persistence will try to  reconnect to redis sentinel.

The logic to reconnect is teardown the old connection and start from a clean state again.

@zendesk/radar @abmartinr @niallcolfer @zendesk/argonauts 