### PR TITLE
Fix Error - ReplyError: NOAUTH Authentication required.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -133,7 +133,8 @@ Connection.prototype.connectRedis = function (config, callback) {
     port: config.port,
     host: config.host,
     enableReadyCheck: true,
-    showFriendlyErrorStack: true
+    showFriendlyErrorStack: true,
+    password: config.redis_auth
   })
   if (config.redis_auth) {
     client.auth(config.redis_auth)


### PR DESCRIPTION
### Description

If the redis server is configured with requirepass the library will not connect and throw the following error: ReplyError: NOAUTH Authentication required.

The fix is to supply the redis server password in the password property of the redis options which are passed in the constructor.

See line 71 https://github.com/luin/ioredis/blob/v4.28.5/lib/redis/RedisOptions.ts

### References

* Jira:
* Github issue:

### Risks

* Low
* Rollback:
