### PR TITLE
Allow tls option when connecting to Redis

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -129,7 +129,7 @@ Connection.prototype.teardown = function (callback) {
 }
 
 Connection.prototype.connectRedis = function (config, callback) {
-  const client = new Redis({
+  var client = new Redis({
     port: config.port,
     host: config.host,
     enableReadyCheck: true,
@@ -137,6 +137,17 @@ Connection.prototype.connectRedis = function (config, callback) {
   })
   if (config.redis_auth) {
     client.auth(config.redis_auth)
+  }
+
+  if (config.tls && config.redis_auth) {
+    client = new Redis({
+      port: config.port,
+      host: config.host,
+      password: config.redis_auth,
+      enableReadyCheck: true,
+      showFriendlyErrorStack: true,
+      tls: true
+    })
   }
 
   client.on('ready', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "persistence",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "persistence",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "ioredis": "^4.28.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persistence",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "An abstraction library for redis and sentinel connection management",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
### Description
It allows to use the TLS option provided by [ioredis](https://github.com/redis/ioredis?tab=readme-ov-file#tls-options)
when the attribute config.tls exists. 

### Risks

* Low : It doesn't change existing functionality. Risk of failing connections to Redis.
* Rollback: revert this PR
