### PR TITLE
Add ioredis v5 support for Valkey v8.2 compatibility

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -129,26 +129,24 @@ Connection.prototype.teardown = function (callback) {
 }
 
 Connection.prototype.connectRedis = function (config, callback) {
-  var client = new Redis({
+  const clientOptions = {
     port: config.port,
     host: config.host,
     enableReadyCheck: true,
     showFriendlyErrorStack: true
-  })
-  if (config.redis_auth) {
-    client.auth(config.redis_auth)
   }
 
-  if (config.tls && config.redis_auth) {
-    client = new Redis({
-      port: config.port,
-      host: config.host,
-      password: config.redis_auth,
-      enableReadyCheck: true,
-      showFriendlyErrorStack: true,
-      tls: true
-    })
+  // Add password if provided (ioredis v5 compatible)
+  if (config.redis_auth) {
+    clientOptions.password = config.redis_auth
   }
+
+  // Add TLS if enabled
+  if (config.tls) {
+    clientOptions.tls = true
+  }
+
+  const client = new Redis(clientOptions)
 
   client.on('ready', function () {
     logging.info('Redis client "ready" event.')
@@ -161,7 +159,6 @@ Connection.prototype.connectRedis = function (config, callback) {
 }
 
 Connection.prototype.connectSentinel = function (config, callback) {
-  const options = { role: 'sentinel' }
   const sentinelMaster = config.id
   const sentinels = config.sentinels
 
@@ -170,17 +167,20 @@ Connection.prototype.connectSentinel = function (config, callback) {
     return
   }
 
-  if (config.redis_auth) {
-    options.auth_pass = config.redis_auth
-  }
-
-  const sentinel = new Redis({
+  const sentinelOptions = {
     sentinels,
     name: sentinelMaster,
-    sentinelPassword: options.auth_pass,
     enableReadyCheck: true,
     showFriendlyErrorStack: true
-  })
+  }
+
+  // Add password and sentinel password if provided (ioredis v5 compatible)
+  if (config.redis_auth) {
+    sentinelOptions.password = config.redis_auth
+    sentinelOptions.sentinelPassword = config.redis_auth
+  }
+
+  const sentinel = new Redis(sentinelOptions)
 
   sentinel.on('ready', function () {
     logging.info('Sentinel client "ready" event.')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persistence",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "An abstraction library for redis and sentinel connection management",
   "main": "lib/index.js",
   "scripts": {
@@ -31,6 +31,6 @@
     "standard": "^16.0.4"
   },
   "dependencies": {
-    "ioredis": "^4.28.5"
+    "ioredis": "^5.0.0"
   }
 }


### PR DESCRIPTION
- Replace deprecated client.auth() with password in constructor options
- Simplify connectRedis to use single client creation with all options
- Update Sentinel connection to use password option consistently
- Bump ioredis dependency from ^4.28.5 to ^5.0.0
- Bump version to 2.3.0

### Description

Describe the original problem and the changes made on this PR.

### References

* Jira: [COMPASS-3927](https://zendesk.atlassian.net/browse/COMPASS-3927)

### Risks

* High: Major version change in Redis dependency. Any issues should be caught on startup
* Rollback: Revert this PR


[COMPASS-3927]: https://zendesk.atlassian.net/browse/COMPASS-3927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ